### PR TITLE
정적 빌드 시 base URL 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,5 +54,5 @@
     "@types/react-helmet": "^6.1.11",
     "@types/styled-components": "^5.1.34"
   },
-  "homepage": "https://Release-Management-Team.github.io/Release-Frontend"
+  "homepage": "https://release.sogang.ac.kr/"
 }


### PR DESCRIPTION
리액트에서 정적 페이지를 만들 때 `package.json`에서 `homepage` 키를 찾아 base URL을 유추하는데, 이를 GitHub Pages 링크로 설정할 경우 학회 서버용으로 빌드할 때 올바른 빌드 결과물이 생성되지 않습니다.

이 PR은 `homepage` 키를 학회 소유 URL로 설정하여 이 문제를 해결합니다.