### PR TITLE
카카오톡 링크 공유를 위한 opengraph 메타 태그 추가

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5,10 +5,9 @@
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
-    <meta
-      name="description"
-      content="Web site created using create-react-app"
-    />
+    <meta name="description" content="서강대학교 컴퓨터공학과 학회 Release" />
+    <meta property="og:title" content="Release" />
+    <meta property="og:description" content="서강대학교 컴퓨터공학과 학회 Release" />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--
       manifest.json provides metadata used when your web app is installed on a


### PR DESCRIPTION
카카오톡 등의 sns에서 링크를 공유하였을 때 뜨는 정보란에 React App으로 뜨는 문제점을 해결하기 위해 opengraph 메타 태그를 추가하였습니다.